### PR TITLE
Initial support for BtVS: Chaos Bleeds (Xbox)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ _(Priority currently lies with Spyro and G-Force)_
 | Game (EDB Version)                             | Textures <sup>[1]</sup> | Maps | Scripts | Entities | Animations | Particles | Spreadsheets |
 | ---------------------------------------------- | ----------------------- | ---- | ------- | -------- | ---------- | --------- | ------------ |
 | Sphinx and the Shadow of Set Demo Disc (156)   | ✅/❌                     | ❌    | ❌       | ✅/❌      | ❌          | ❌         | ✅/❌          |
+| Buffy The Vampire Slayer: Chaos Bleeds (170)   | ✅/❌                     | ❌    | ❌       | ✅/❌      | ❌          | ❌         | ❔/❌          |
 | Sphinx and the Cursed Mummy (182)              | ✅/❌                     | ❌    | ❌       | ✅/❌      | ❌          | ❌         | ✅/❌          |
 | Spyro: A Hero's Tail (240)                     | ✅/❌                     | ✅/❌  | ❌       | ✅/❌      | ❌          | ❌         | ✅/❌          |
 | Robots (248)                                   | ✅/❌                     | ✅/❌  | ❌       | ✅/❌      | ❌          | ❌         | ✅/❌          |

--- a/eurochef-edb/src/edb.rs
+++ b/eurochef-edb/src/edb.rs
@@ -74,7 +74,7 @@ impl EdbFile {
             ));
         }
 
-        if !(182..=263).contains(&version) {
+        if !(170..=263).contains(&version) {
             return Err(crate::error::EurochefError::Unsupported(
                 crate::error::UnsupportedError::Version(version),
             ));

--- a/eurochef-edb/src/entity_mesh.rs
+++ b/eurochef-edb/src/entity_mesh.rs
@@ -87,7 +87,7 @@ impl BinRead for EXGeoMeshEntity {
                 });
             } else {
                 match version {
-                    252 | 250 | 251 | 240 | 221 => {
+                    252 | 250 | 251 | 240 | 221 | 170 => {
                         let d = reader.read_type::<(EXVector3, u32, EXVector2)>(endian)?;
                         vertices.push(UXGeoMeshVertex {
                             pos: d.0,

--- a/eurochef-edb/src/texture.rs
+++ b/eurochef-edb/src/texture.rs
@@ -62,8 +62,9 @@ pub struct EXGeoTexture {
     pub clut_offset: Option<EXRelPtr>,
 
     /// Certain platforms such as PC and PS2 calculate data size from other parameters.
+    /// Some games (e.g. Chaos Bleeds on Xbox) also seem to do this.
     /// For general usage it is not recommended to rely on this field exlusively for data size.
-    #[brw(if(platform != Platform::Pc && platform != Platform::Ps2))]
+    #[brw(if(platform != Platform::Pc && platform != Platform::Ps2 && !(version == 170 && platform == Platform::Xbox)))]
     pub data_size: Option<u32>,
 
     #[br(count = image_count)]


### PR DESCRIPTION
This adds the small special case changes needed to provide initial support for _Buffy The Vampire Slayer: Chaos Bleeds_. This has thus far been tested only against the Xbox version of the game.

Enables extraction of meshes and textures, allowing entities to be fully extracted, but currently does not support full extraction of maps (similar to _Sphinx and the Shadow of Set Demo Disc_ and _Sphinx and the Cursed Mummy_). Spreadsheets are currently untested.